### PR TITLE
hide ~~NOTODO~~ from wiki pages

### DIFF
--- a/syntax/todo.php
+++ b/syntax/todo.php
@@ -141,6 +141,7 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
      */
     public function connectTo($mode) {
         $this->Lexer->addEntryPattern('<todo[\s]*?.*?>(?=.*?</todo>)', $mode, 'plugin_todo_todo');
+        $this->Lexer->addSpecialPattern('~~NOTODO~~', $mode, 'plugin_todo_todo');
     }
 
     public function postConnect() {


### PR DESCRIPTION
This hides the new `~~NOTODO~~` tag from wiki pages. See #49