### PR TITLE
Change that items of TodoList are not clickable.

### DIFF
--- a/syntax/todo.php
+++ b/syntax/todo.php
@@ -346,7 +346,7 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
         }
 
         $spanclass = 'todotext';
-        if($this->getConf("CheckboxText") && !$this->getConf("AllowLinks") && $data['checkbox']) {
+        if($this->getConf("CheckboxText") && !$this->getConf("AllowLinks") && $oldID == $ID && $data['checkbox']) {
             $spanclass .= ' clickabletodo todohlght';
         }
         if(isset($bg)) $spanclass .= ' '.$bg;


### PR DESCRIPTION
Sorry for my terrible English.

Now, items of TodoList are internal links.

If todo item is external links, it is unclickable class.
However, if todo item is internal links, especially TodoList members, it is clickable class.

So, selecting todolist item, it was checked and go link page.
I want to change this.
