### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax/list.php
+++ b/syntax/list.php
@@ -52,7 +52,7 @@ class syntax_plugin_todo_list extends syntax_plugin_todo_todo {
      * @param Doku_Handler $handler The handler
      * @return array Data for the renderer
      */
-    public function handle($match, $state, $pos, Doku_Handler &$handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
 
         $options = substr($match, 10, -2); // strip markup
         $options = explode(' ', $options);
@@ -156,7 +156,7 @@ class syntax_plugin_todo_list extends syntax_plugin_todo_todo {
      * @param array $data The data from the handler() function
      * @return bool If rendering was successful.
      */
-    public function render($mode, Doku_Renderer &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         global $conf;
 
         if($mode != 'xhtml') return false;

--- a/syntax/todo.php
+++ b/syntax/todo.php
@@ -157,7 +157,7 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
      * @param &$handler Doku_Handler  Reference to the Doku_Handler object.
      * @return int The current lexer state for the match.
      */
-    public function handle($match, $state, $pos, Doku_Handler &$handler) {
+    public function handle($match, $state, $pos, Doku_Handler $handler) {
         switch($state) {
             case DOKU_LEXER_ENTER :
                 #Search to see if the '#' is in the todotag (if so, this means the Action has been completed)
@@ -212,7 +212,7 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
      * @param  $data     Array         The data created by the <tt>handle()</tt> method.
      * @return Boolean true: if rendered successfully, or false: otherwise.
      */
-    public function render($mode, Doku_Renderer &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         global $ID;
         list($state, $todotitle) = $data;
         if($mode == 'xhtml') {


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.