### PR TITLE
Added missing space before "checked" attribute

### DIFF
--- a/syntax/todo.php
+++ b/syntax/todo.php
@@ -313,7 +313,7 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
             . ' data-date="' . hsc(@filemtime(wikiFN($ID))) . '"'
             . ' data-pageid="' . hsc($ID) . '"'
             . ' data-strikethrough="' . ($this->getConf("Strikethrough") ? '1' : '0') . '"'
-            . ($checked ? 'checked="checked"' : '') . ' /> ';
+            . ($checked ? ' checked="checked"' : '') . ' /> ';
         }
 
         // Username of first todouser in list


### PR DESCRIPTION
ToDo item is not well HTML formatted because lack a space before "checked" attribute.

This PR fix an issue on Bootstrap3 template (LotarProject/dokuwiki-template-bootstrap3#354)

Thanks,
Joseph