### PR TITLE
return empty array if there are no todo pages

### DIFF
--- a/syntax/list.php
+++ b/syntax/list.php
@@ -331,8 +331,8 @@ class syntax_plugin_todo_list extends syntax_plugin_todo_todo {
      */
     private function filterpages($todopages, $data) {
         // skip function if $todopages has no values
+        $pages = array();
         if(isset($todopages) && count($todopages)>0) {
-            $pages = array();
             foreach($todopages as $page) {
                 $todos = array();
                 // contains 3 arrays: an array with complete matches and 2 arrays with subpatterns
@@ -347,9 +347,8 @@ class syntax_plugin_todo_list extends syntax_plugin_todo_todo {
                     $pages[] = array('id' => $page['id'], 'todos' => $todos);
                 }
             }
-            return $pages;
         }
-        return null;
+        return $pages;
     }
 
 


### PR DESCRIPTION
Calling function expects an array.
Returning an empty array instead of null saves a null check and also makes sense when reasoning about the function.

Fixes #145 