### PR TITLE
Allow empty todos

### DIFF
--- a/syntax/list.php
+++ b/syntax/list.php
@@ -386,7 +386,10 @@ class syntax_plugin_todo_list extends syntax_plugin_todo_todo {
                 $R->tablerow_close();
        	    }
             foreach($page['todos'] as $todo) {
-//echo "<pre>";var_dump($todo);echo "</pre>";
+                if(empty($todo['todotitle']))
+                {
+                    $todo['todotitle'] = '<no title>';
+                }
                 $R->tablerow_open();
                 $R->tablecell_open();
                 $R->doc .= $this->createTodoItem($R, $page['id'], array_merge($todo, $data));

--- a/syntax/todo.php
+++ b/syntax/todo.php
@@ -152,7 +152,13 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
      */
     public function render($mode, Doku_Renderer $renderer, $data) {
         global $ID;
-        list($state, $todotitle) = $data;
+        
+        if(empty($data)) {
+            return false;
+        }
+
+        [$state] = $data;
+
         if($mode == 'xhtml') {
             /** @var $renderer Doku_Renderer_xhtml */
             if($state == DOKU_LEXER_UNMATCHED) {
@@ -160,13 +166,6 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
                 #Output our result
                 $renderer->doc .= $this->createTodoItem($renderer, $ID, array_merge($data, array('checkbox'=>'yes')));
                 return true;
-            }
-
-        } elseif($mode == 'metadata') {
-            /** @var $renderer Doku_Renderer_metadata */
-            if($state == DOKU_LEXER_UNMATCHED) {
-                $id = $this->_composePageid($todotitle);
-                $renderer->internallink($id, $todotitle);
             }
         }
         return false;
@@ -336,8 +335,8 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
                 global $auth;
                 $username = $auth->getUserData($username)['name'];
                 break;
-            case "none": 
-                $username=""; 
+            case "none":
+                $username="";
                 break;
             case "user":
             default:

--- a/syntax/todo.php
+++ b/syntax/todo.php
@@ -106,6 +106,7 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
                 }
                 $handler->todo_user = '';
                 $handler->checked = '';
+                $handler->todotitle = '';
                 break;
             case DOKU_LEXER_MATCHED :
                 break;
@@ -119,22 +120,17 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
                  * -</a> or </span>
                  * </span>
                  */
-
-                #Make sure there is actually an action to create
-                if(trim($match) != '') {
-
-                    $data = array_merge(array ($state, 'todotitle' => $match, 'todoindex' => $handler->todo_index, 'todouser' => $handler->todo_user, 'checked' => $handler->checked), $handler->todoargs);
-                    $handler->todo_index++;
-                    return $data;
-                }
-
+                $handler->todotitle = $match;
                 break;
             case DOKU_LEXER_EXIT :
+                $data = array_merge(array ($state, 'todotitle' => $handler->todotitle, 'todoindex' => $handler->todo_index, 'todouser' => $handler->todo_user, 'checked' => $handler->checked), $handler->todoargs);
+                $handler->todo_index++;
                 #Delete temporary checked variable
                 unset($handler->todo_user);
                 unset($handler->checked);
                 unset($handler->todoargs);
-                //unset($handler->todo_index);
+                unset($handler->todotitle);
+                return $data;
                 break;
             case DOKU_LEXER_SPECIAL :
                 break;
@@ -152,7 +148,7 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
      */
     public function render($mode, Doku_Renderer $renderer, $data) {
         global $ID;
-        
+
         if(empty($data)) {
             return false;
         }
@@ -161,8 +157,7 @@ class syntax_plugin_todo_todo extends DokuWiki_Syntax_Plugin {
 
         if($mode == 'xhtml') {
             /** @var $renderer Doku_Renderer_xhtml */
-            if($state == DOKU_LEXER_UNMATCHED) {
-
+            if($state == DOKU_LEXER_EXIT) {
                 #Output our result
                 $renderer->doc .= $this->createTodoItem($renderer, $ID, array_merge($data, array('checkbox'=>'yes')));
                 return true;


### PR DESCRIPTION
This allows the usage of empty todo items (`<todo></todo>`) or todo items with only whitespace (`<todo> </todo>`).

```
<todo>First todo</todo>

<todo>Second todo</todo>

<todo due:2033-03-03>Third</todo>

<todo> </todo>

<todo due:2033-03-03></todo>

<todo due:2033-03-03 #robert:2023-07-11> </todo>

<todo>Last todo</todo>
```

![image](https://github.com/leibler/dokuwiki-plugin-todo/assets/80354943/3c41bced-2d96-45ce-b44e-1cd7591abcc4)

Currently, these items are not allowed/properly processed and lead to problems displaying them or interacting with them (see #138, #149 and #151). Treating them like any other todo item solves these problems. I do not see a downside, as this behaviour then also corresponds with user expectations.

If they are included in a todo list, their title would be displayed as `<no title>`. I do not see why this would be used though, but just in case.

![image](https://github.com/leibler/dokuwiki-plugin-todo/assets/80354943/757c66d2-993a-491a-8f84-b6113cca6b6c)

I tested it locally and everything seems to work fine.

