### PR TITLE
Adds button to reset all ToDos on the page

### DIFF
--- a/action.php
+++ b/action.php
@@ -87,7 +87,7 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
             // path = page ID
             $ID = cleanID(urldecode($_REQUEST['pageid']));
         } else {
-            return;    
+            return;
         }
 
         if($mode == 'checkbox') {
@@ -135,15 +135,13 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
 
         switch($mode) {
             case 'checkbox':
-                switch($mode) {
-            case 'checkbox':
                 #Determine position of tag
-                        if($index >= 0) {
-                            $index++;
-                            // index is only set on the current page with the todos
-                            // the occurances are counted, untill the index-th input is reached which is updated
-                            $todoTagStartPos = $this->_strnpos($wikitext, '<todo', $index);
-                            $todoTagEndPos = strpos($wikitext, '>', $todoTagStartPos) + 1;
+                if($index >= 0) {
+                    $index++;
+                    // index is only set on the current page with the todos
+                    // the occurances are counted, untill the index-th input is reached which is updated
+                    $todoTagStartPos = $this->_strnpos($wikitext, '<todo', $index);
+                    $todoTagEndPos = strpos($wikitext, '>', $todoTagStartPos) + 1;
 
                             if($todoTagEndPos > $todoTagStartPos) {
                                 // @date 20140714 le add todo text to minorchange

--- a/action.php
+++ b/action.php
@@ -82,16 +82,23 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
 
         #Variables
         // by einhirn <marg@rz.tu-clausthal.de> determine checkbox index by using class 'todocheckbox'
-
-        if(isset($_REQUEST['index'], $_REQUEST['checked'], $_REQUEST['pageid'])) {
-            // index = position of occurrence of <input> element (starting with 0 for first element)
-            $index = (int) $_REQUEST['index'];
-            // checked = flag if input is checked means to do is complete (1) or not (0)
-            $checked = (boolean) urldecode($_REQUEST['checked']);
+        if(isset($_REQUEST['mode'], $_REQUEST['pageid'])) {
+            $mode = $_REQUEST['mode'];
             // path = page ID
             $ID = cleanID(urldecode($_REQUEST['pageid']));
         } else {
-            return;
+            return;    
+        }
+
+        if($mode == 'checkbox') {
+            if(isset($_REQUEST['index'], $_REQUEST['checked'], $_REQUEST['pageid'])) {
+                // index = position of occurrence of <input> element (starting with 0 for first element)
+                $index = (int) $_REQUEST['index'];
+                // checked = flag if input is checked means to do is complete (1) or not (0)
+                $checked = (boolean) urldecode($_REQUEST['checked']);
+            } else {
+                return;
+            }
         }
 
         $date = 0;
@@ -126,27 +133,46 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
         #Retrieve Page Contents
         $wikitext = rawWiki($ID);
 
-        #Determine position of tag
-        if($index >= 0) {
-            $index++;
-            // index is only set on the current page with the todos
-            // the occurances are counted, untill the index-th input is reached which is updated
-            $todoTagStartPos = $this->_strnpos($wikitext, '<todo', $index);
-            $todoTagEndPos = strpos($wikitext, '>', $todoTagStartPos) + 1;
+        switch($mode) {
+            case 'checkbox':
+                switch($mode) {
+            case 'checkbox':
+                #Determine position of tag
+                        if($index >= 0) {
+                            $index++;
+                            // index is only set on the current page with the todos
+                            // the occurances are counted, untill the index-th input is reached which is updated
+                            $todoTagStartPos = $this->_strnpos($wikitext, '<todo', $index);
+                            $todoTagEndPos = strpos($wikitext, '>', $todoTagStartPos) + 1;
 
-            if($todoTagEndPos > $todoTagStartPos) {
-                // @date 20140714 le add todo text to minorchange
-                $todoTextEndPos = strpos( $wikitext, '</todo', $todoTagEndPos );
-                $todoText = substr( $wikitext, $todoTagEndPos, $todoTextEndPos-$todoTagEndPos );
-                // update text
-                $oldTag = substr($wikitext, $todoTagStartPos, ($todoTagEndPos - $todoTagStartPos));
-                $newTag = $this->_buildTodoTag($oldTag, $checked);
-                $wikitext = substr_replace($wikitext, $newTag, $todoTagStartPos, ($todoTagEndPos - $todoTagStartPos));
+                            if($todoTagEndPos > $todoTagStartPos) {
+                                // @date 20140714 le add todo text to minorchange
+                                $todoTextEndPos = strpos( $wikitext, '</todo', $todoTagEndPos );
+                                $todoText = substr( $wikitext, $todoTagEndPos, $todoTextEndPos-$todoTagEndPos );
+                                // update text
+                                $oldTag = substr($wikitext, $todoTagStartPos, ($todoTagEndPos - $todoTagStartPos));
+                                $newTag = $this->_buildTodoTag($oldTag, $checked);
+                                $wikitext = substr_replace($wikitext, $newTag, $todoTagStartPos, ($todoTagEndPos - $todoTagStartPos));
 
-                // save Update (Minor)
+                                // save Update (Minor)
+                                lock($ID);
+                                // @date 20140714 le add todo text to minorchange, use different message for checked or unchecked
+                                saveWikiText($ID, $wikitext, $this->getLang($checked?'checkboxchange_on':'checkboxchange_off').': '.$todoText, $minoredit = true);
+                                unlock($ID);
+
+                        $return = array(
+                            'date' => @filemtime(wikiFN($ID)),
+                            'succeed' => true
+                        );
+                        $this->printJson($return);
+                    }
+                }
+                break;
+            case 'uncheckall':
+                $newWikitext = preg_replace('/(<todo.*?)(\s+#[^>\s]*)(.*?>|\s.*?<\/todo>)/', '$1$3', $wikitext);
+
                 lock($ID);
-                // @date 20140714 le add todo text to minorchange, use different message for checked or unchecked
-                saveWikiText($ID, $wikitext, $this->getLang($checked?'checkboxchange_on':'checkboxchange_off').': '.$todoText, $minoredit = true);
+                saveWikiText($ID, $newWikitext, 'Unchecked all ToDos', $minoredit = true);
                 unlock($ID);
 
                 $return = array(
@@ -154,7 +180,7 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
                     'succeed' => true
                 );
                 $this->printJson($return);
-            }
+                break;
         }
     }
 
@@ -184,7 +210,6 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
         }
         return $newTag;
     }
-
 
     /**
      * Find position of $occurance-th $needle in haystack


### PR DESCRIPTION
This change allows you to reset all checkboxes on a page with the press of a button. The reset is stored as a single edit in the page history. This is very helpful if you need to uncheck all ToDos regularly as you don't need to click them all separately and it doesn't clutter the edit history.

This covers also the uncheck bit of #158.

## Usage

Add `~~TODO:UNCHECKALL~~` to the page. This generates a button with the label "Uncheck all todos".
![image](https://github.com/leibler/dokuwiki-plugin-todo/assets/80354943/9c1105e3-cbdb-441f-b32d-bd831559ed7f)
Once clicked, all ToDos of this page are reset.
![image](https://github.com/leibler/dokuwiki-plugin-todo/assets/80354943/02dc01e5-87c1-4d89-a71d-f272814325c0)
A minor edit with the summary "Unchecked all ToDos" is created.

## Implementation

### syntax.php

Adds the new pattern as
`const TODO_UNCHECK_ALL = '~~TODO:UNCHECKALL~~';`
and replaces it with the button for the generated page:
`$renderer->doc .= '<button type="button" class="todouncheckall">Uncheck all todos</button>';`

### script.js

The uncheck function is bound to the click event of this button:
```
jQuery('button.todouncheckall').click(function () {
        ToDoPlugin.uncheckall();
    });
```
The function then leads to an ajax call:
```
        jQuery.post(
            DOKU_BASE + 'lib/exe/ajax.php',
            {
                call: 'plugin_todo',
                mode: 'uncheckall',
                pageid: jQuery('input.todocheckbox:first').data().pageid
            },
        whenCompleted, 'json');
```

To distinguish between the click of a ToDo and this button, a new parameter `mode` is added:
`mode: 'checkbox'` & `mode: 'uncheckall'`

On completion, the current page is also modified to reset all ToDos:
```
var whenCompleted = function () {
            jQuery('input.todocheckbox').each(function() {
                jQuery(this).prop('checked', false);
            });

            jQuery('span.todoinnertext').each(function () {
                if (jQuery(this).parent().is("del")) {
                    jQuery(this).unwrap();
                }
            });

            jQuery('span.todouser').each(function () {
                jQuery(this).remove();
            });
            
            ToDoPlugin.locked = false;
        };
```
This is only for an immediate feedback. The permanent change is the one from the ajax call.

### action.php

Includes a slight rewrite of the way the parameters are read to adapt it to the introduction of modes.

The actually relevant addition is the replacement of the checked markers with regex, # and any following non-whitespace character is removed:
`$newWikitext = preg_replace('/(<todo.*?)(\s+#[^>\s]*)(.*?>|\s.*?<\/todo>)/', '$1$3', $wikitext);`

The new wiki text is then saved as a minor edit:
`saveWikiText($ID, $newWikitext, 'Unchecked all ToDos', $minoredit = true);`

## Testing

I tested this with a lot of possible combinations of attributes (@, due, start).

## Possible improvements

The label of the new button and the edit summary are hard-coded in English. Translations for all the currently available languages could be added.