### PR TITLE
fixes #137 in part - prevents edit of parent page without todo tag

### DIFF
--- a/action.php
+++ b/action.php
@@ -143,7 +143,7 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
                     $todoTagStartPos = $this->_strnpos($wikitext, '<todo', $index);
                     $todoTagEndPos = strpos($wikitext, '>', $todoTagStartPos) + 1;
 
-                            if($todoTagEndPos > $todoTagStartPos) {
+                            if($todoTagStartPos!==false && $todoTagEndPos > $todoTagStartPos) { 
                                 // @date 20140714 le add todo text to minorchange
                                 $todoTextEndPos = strpos( $wikitext, '</todo', $todoTagEndPos );
                                 $todoText = substr( $wikitext, $todoTagEndPos, $todoTextEndPos-$todoTagEndPos );
@@ -163,6 +163,7 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
                             'succeed' => true
                         );
                         $this->printJson($return);
+			
                     }
                 }
                 break;
@@ -214,7 +215,11 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
      */
     private function _strnpos($haystack, $needle, $occurance, $pos = 0) {
         for($i = 1; $i <= $occurance; $i++) {
-            $pos = strpos($haystack, $needle, $pos) + 1;
+            $pos = strpos($haystack, $needle, $pos);
+
+            if ($pos===false) {return false; }
+
+            $pos++;
         }
         return $pos - 1;
     }


### PR DESCRIPTION
Checks whether there actually is an opening `<todo` tag before inserting a change.

This prevents edit of parent page without todo tag when it includes a page with todos.
If there were todos in parent as well as included page, it would perhaps still break something or do nothing depending on whether the include appears before or after the todo tag in parent page, because we can only count the rendered todos in javascript, not in wiki source.