### PR TITLE
Update plugin.info.txt to fix #171

### DIFF
--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -3,5 +3,5 @@ author Leo Eibler, Christian Marg, Markus Gschwendt, Robert Weinmeister
 email  dokuwiki@sprossenwanne.at, marg@rz.tu-clausthal.de, develop@weinmeister.org
 date   2024-04-27
 name   ToDo
-desc   Create a checkbox based todo list with optional user assignment (by using <todo @user>This is a ToDo</todo>). It can also be used as a lightweight task list management system.
+desc   Create a checkbox based todo list with optional user assignment (basic syntax: <todo>This is a ToDo</todo>). It can also be used as a lightweight task list management system.
 url    https://www.dokuwiki.org/plugin:todo

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -1,7 +1,7 @@
 base   todo
 author Leo Eibler, Christian Marg, Markus Gschwendt, Robert Weinmeister
 email  dokuwiki@sprossenwanne.at, marg@rz.tu-clausthal.de, develop@weinmeister.org
-date   2024-03-04
+date   2024-04-27
 name   ToDo
-desc   Create a checkbox based todo list with optional user assignment (by using <todo>This is a ToDo</todo>). In combination with dokuwiki searchpattern plugin it is a lightweight task list management system.
+desc   Create a checkbox based todo list with optional user assignment (by using <todo @user>This is a ToDo</todo>). In addition this plug-in provides a lightweight task list management system. Please refer to the Doku page.
 url    https://www.dokuwiki.org/plugin:todo

--- a/plugin.info.txt
+++ b/plugin.info.txt
@@ -3,5 +3,5 @@ author Leo Eibler, Christian Marg, Markus Gschwendt, Robert Weinmeister
 email  dokuwiki@sprossenwanne.at, marg@rz.tu-clausthal.de, develop@weinmeister.org
 date   2024-04-27
 name   ToDo
-desc   Create a checkbox based todo list with optional user assignment (by using <todo @user>This is a ToDo</todo>). In addition this plug-in provides a lightweight task list management system. Please refer to the Doku page.
+desc   Create a checkbox based todo list with optional user assignment (by using <todo @user>This is a ToDo</todo>). It can also be used as a lightweight task list management system.
 url    https://www.dokuwiki.org/plugin:todo


### PR DESCRIPTION
Update plugin.info.txt as applicable to delete false advertising of outdated 'searchpattern' plug-in which was made obsolete since the year 2014 already.

ref https://github.com/leibler/dokuwiki-plugin-todo/issues/171

Keep on the good work and prosper.