### PR TITLE
Replaces deprecated JSON class

### DIFF
--- a/action.php
+++ b/action.php
@@ -189,8 +189,7 @@ class action_plugin_todo extends DokuWiki_Action_Plugin {
      * @param mixed $return
      */
     private function printJson($return) {
-        $json = new JSON();
-        echo $json->encode($return);
+        echo json_encode($return);
     }
 
     /**


### PR DESCRIPTION
Replaces the deprecated JSON class as suggested
https://www.dokuwiki.org/devel:releases:refactor2020#json_class_is_deprecated

This fixes #179 and #180.
